### PR TITLE
chore: add Slack CLI support

### DIFF
--- a/.slack/.gitignore
+++ b/.slack/.gitignore
@@ -1,0 +1,2 @@
+apps.dev.json
+cache/

--- a/.slack/hooks.json
+++ b/.slack/hooks.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "get-hooks": "npx -q --no-install -p @slack/cli-hooks slack-cli-get-hooks"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,35 @@ channels between the same two organizations
 Before getting started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create).
 ## Installation
 
+### Using Slack CLI
+
+Install the latest version of the Slack CLI for your operating system:
+
+- [Slack CLI for macOS & Linux](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux/)
+- [Slack CLI for Windows](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-windows/)
+
+You'll also need to log in if this is your first time using the Slack CLI.
+
+```sh
+slack login
+```
+
+#### Initializing the project
+
+```sh
+slack create bolt-js-slack-connect-admin --template slack-samples/bolt-js-slack-connect-admin
+cd bolt-js-slack-connect-admin
+```
+
+#### Running the app
+
+```sh
+slack run
+```
+
+<details>
+<summary><h3>Using Terminal</h3></summary>
+
 #### Create a Slack App
 
 1. Open [https://api.slack.com/apps/new](https://api.slack.com/apps/new) and choose "From an app manifest"
@@ -87,6 +116,8 @@ That's it! You now have all the info to set your environmental variables to conn
 #### Run Bolt Server
 
 `npm start`
+
+</details>
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.4",
+        "@slack/cli-hooks": "^2.0.0",
         "ngrok": "^4.3.3"
       }
     },
@@ -236,6 +237,28 @@
       },
       "peerDependencies": {
         "@types/express": "^5.0.0"
+      }
+    },
+    "node_modules/@slack/cli-hooks": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/cli-hooks/-/cli-hooks-2.0.0.tgz",
+      "integrity": "sha512-VLxGqJZwbrH3S+ovRhqlrcrKWHRDJtn3toraZKAcLaPqca5CgqTa/PmiCvCq3uUowiFw9B7FOB0y3ikQoDppTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "slack-cli-check-update": "src/check-update.js",
+        "slack-cli-doctor": "src/doctor.js",
+        "slack-cli-get-hooks": "src/get-hooks.js",
+        "slack-cli-get-manifest": "src/get-manifest.js",
+        "slack-cli-start": "src/start.js"
+      },
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@slack/logger": {
@@ -1430,6 +1453,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mongodb": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.4",
+    "@slack/cli-hooks": "^2.0.0",
     "ngrok": "^4.3.3"
   }
 }


### PR DESCRIPTION
This standardizes Slack CLI support for this sample so it can be created and run with the Slack CLI (`slack create` / `slack run`), matching the other CLI-enabled Bolt samples.

Adds (only the pieces this repo was missing):
- `.slack/hooks.json` — the CLI `get-hooks` config
- `.slack/.gitignore` — ignores `apps.dev.json` and `cache/` (local CLI state)
- the CLI hooks dependency (`@slack/cli-hooks` for JS/TS, `slack-cli-hooks==0.3.0` for Python)
- a `### Using Slack CLI` README section, with the existing manual flow preserved under `Using Terminal`

Opened as a **draft** for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)